### PR TITLE
initial 3.0 updates

### DIFF
--- a/seedbuilder/generator.py
+++ b/seedbuilder/generator.py
@@ -249,7 +249,8 @@ class SeedGenerator:
             "Grenade": 29, "GinsoKey": 12, "ForlornKey": 12, "HoruKey": 12,
             "Water": 80, "Wind": 80, "WaterVeinShard": 5, "GumonSealShard": 5,
             "SunstoneShard": 5, "TPForlorn": 120, "TPGrotto": 60,
-            "TPSorrow": 90, "TPGrove": 60, "TPSwamp": 60, "TPValley": 90
+            "TPSorrow": 90, "TPGrove": 60, "TPSwamp": 60, "TPValley": 90,
+            "TPGinso": 150, "TPHoru": 180, "Open": 1
         })
         self.inventory = OrderedDict([
             ("EX1", 0), ("EX*", 0), ("KS", 0), ("MS", 0), ("AC", 0), ("EC", 1),
@@ -261,7 +262,8 @@ class SeedGenerator:
             ("RB9", 0), ("RB10", 0), ("RB11", 0), ("RB12", 0), ("RB13", 0),
             ("RB15", 0), ("WaterVeinShard", 0), ("GumonSealShard", 0),
             ("SunstoneShard", 0), ("TPForlorn", 0), ("TPGrotto", 0),
-            ("TPSorrow", 0), ("TPGrove", 0), ("TPSwamp", 0), ("TPValley", 0)
+            ("TPSorrow", 0), ("TPGrove", 0), ("TPSwamp", 0), ("TPValley", 0),
+            ("TPGinso", 0), ("TPHoru", 0), ("Open", 0)
         ])
 
         self.mapstonesSeen = 1
@@ -290,7 +292,7 @@ class SeedGenerator:
         self.forcedAssignments = self.preplaced
         self.forceAssignedLocs = set()
         self.itemPool = OrderedDict([
-            ("EX1", 1), ("EX*", 99), ("KS", 40), ("MS", 11), ("AC", 33),
+            ("EX1", 1), ("EX*", 97), ("KS", 40), ("MS", 11), ("AC", 33),
             ("EC", 14), ("HC", 12), ("WallJump", 1), ("ChargeFlame", 1),
             ("Dash", 1), ("Stomp", 1), ("DoubleJump", 1), ("Glide", 1),
             ("Bash", 1), ("Climb", 1), ("Grenade", 1), ("ChargeJump", 1),
@@ -300,8 +302,11 @@ class SeedGenerator:
             ("RB13", 3), ("RB15", 3), ("WaterVeinShard", 0),
             ("GumonSealShard", 0), ("SunstoneShard", 0), ("TPForlorn", 1),
             ("TPGrotto", 1), ("TPSorrow", 1), ("TPGrove", 1), ("TPSwamp", 1),
-            ("TPValley", 1)
+            ("TPValley", 1), ("TPGinso", 1), ("TPHoru", 1), ("Open", 0)
         ])
+        if self.var(Variation.OPEN_MODE):
+            self.inventory["Open"] = 1
+
         if self.var(Variation.FREE_MAPSTONES):
             self.costs["MS"] = 11
 
@@ -309,7 +314,7 @@ class SeedGenerator:
             self.itemPool["AC"] = 0
             self.itemPool["HC"] = 0
             self.itemPool["EC"] = 3
-            self.itemPool["EX*"] = 175
+            self.itemPool["EX*"] = 173
             for bonus in [k for k in self.itemPool.keys() if k[:2] == "RB"]:
                 del self.itemPool[bonus]
 
@@ -861,7 +866,7 @@ class SeedGenerator:
             if ShareType.EVENT in self.params.sync.shared:
                 self.sharedList += ["Water", "Wind", "Warmth"]
             if ShareType.TELEPORTER in self.params.sync.shared:
-                self.sharedList += ["TPForlorn", "TPGrotto", "TPSorrow", "TPGrove", "TPSwamp", "TPValley"]
+                self.sharedList += ["TPForlorn", "TPGrotto", "TPSorrow", "TPGrove", "TPSwamp", "TPValley", "TPGinso", "TPHoru"]
             if ShareType.UPGRADE in self.params.sync.shared:
                 self.sharedList += ["RB6", "RB8", "RB9", "RB10", "RB11", "RB12", "RB13", "RB15"]
                 if self.var(Variation.EXTRA_BONUS_PICKUPS):

--- a/seedbuilder/generator.py
+++ b/seedbuilder/generator.py
@@ -1071,6 +1071,10 @@ class SeedGenerator:
                     itemsToAssign.append(self.assign("KS"))
                 elif self.inventory["MS"] < mapstoneCount:
                     itemsToAssign.append(self.assign("MS"))
+                elif self.inventory["HC"] * self.params.cell_freq < (252 - self.itemCount) and self.itemPool["HC"] > 0:
+                    itemsToAssign.append(self.assign("HC"))
+                elif self.inventory["EC"] * self.params.cell_freq < (252 - self.itemCount) and self.itemPool["EC"] > 0:
+                    itemsToAssign.append(self.assign("EC"))
                 elif self.params.balanced and self.itemCount == 0:
                     itemsToAssign.append(self.balanceListLeftovers.pop(0))
                     self.itemCount += 1

--- a/seedbuilder/generator.py
+++ b/seedbuilder/generator.py
@@ -408,14 +408,18 @@ class SeedGenerator:
         for area in list(self.areasReached.keys()):
             for connection in self.areas[area].get_connections():
                 cost = connection.cost()
+                reached = connection.target in self.areasReached
                 if cost[0] <= 0:
-                    self.areas[connection.target].difficulty = cost[2]
+                    if not reached:
+                        self.areas[connection.target].difficulty = cost[2]
+                        if len(self.areas[connection.target].locations) > 0:
+                            self.areas[connection.target].difficulty += area.difficulty
                     if connection.keys > 0:
                         if area not in self.doorQueue.keys():
                             self.doorQueue[area] = connection
                             keystoneCount += connection.keys
                     elif connection.mapstone:
-                        if connection.target not in self.areasReached:
+                        if not reached:
                             visitMap = True
                             for mp in self.mapQueue.keys():
                                 if mp == area or self.mapQueue[mp].target == connection.target:
@@ -424,7 +428,7 @@ class SeedGenerator:
                                 self.mapQueue[area] = connection
                                 mapstoneCount += 1
                     else:
-                        if connection.target not in self.areasReached:
+                        if not reached:
                             self.seedDifficulty += cost[2] * cost[2]
                             self.reach_area(connection.target)
                         if connection.target in self.areasRemaining:
@@ -678,15 +682,15 @@ class SeedGenerator:
         total = 0.0
         for loc in locationsToAssign:
             if self.params.path_diff == PathDifficulty.EASY:
-                total += (15 - loc.difficulty) * (15 - loc.difficulty)
+                total += (20 - loc.difficulty) * (20 - loc.difficulty)
             else:
                 total += (loc.difficulty * loc.difficulty)
         value = self.random.random()
         position = 0.0
         for i in range(0, len(locationsToAssign)):
             if self.params.path_diff == PathDifficulty.EASY:
-                position += (15 - locationsToAssign[i].difficulty) * (
-                    15 - locationsToAssign[i].difficulty) / total
+                position += (20 - locationsToAssign[i].difficulty) * (
+                    20 - locationsToAssign[i].difficulty) / total
             else:
                 position += locationsToAssign[i].difficulty * \
                     locationsToAssign[i].difficulty / total

--- a/seedbuilder/generator.py
+++ b/seedbuilder/generator.py
@@ -299,7 +299,7 @@ class SeedGenerator:
         self.connectionQueue = []
         self.assignQueue = []
 
-        self.itemCount = 244.0
+        self.itemCount = 252.0
 
     def reset(self):
         """A full reset. Resets internal state completely (besides pRNG
@@ -309,7 +309,7 @@ class SeedGenerator:
         self.forcedAssignments = self.preplaced
         self.forceAssignedLocs = set()
         self.itemPool = OrderedDict([
-            ("EX1", 1), ("EX*", 91), ("KS", 40), ("MS", 11), ("AC", 33),
+            ("EX1", 1), ("EX*", 99), ("KS", 40), ("MS", 11), ("AC", 33),
             ("EC", 14), ("HC", 12), ("WallJump", 1), ("ChargeFlame", 1),
             ("Dash", 1), ("Stomp", 1), ("DoubleJump", 1), ("Glide", 1),
             ("Bash", 1), ("Climb", 1), ("Grenade", 1), ("ChargeJump", 1),
@@ -325,7 +325,7 @@ class SeedGenerator:
             self.itemPool["AC"] = 0
             self.itemPool["HC"] = 0
             self.itemPool["EC"] = 3
-            self.itemPool["EX*"] = 167
+            self.itemPool["EX*"] = 175
             for bonus in [k for k in self.itemPool.keys() if k[:2] == "RB"]:
                 del self.itemPool[bonus]
 

--- a/seedbuilder/generator.py
+++ b/seedbuilder/generator.py
@@ -175,6 +175,7 @@ class Connection:
             score = 0
             energy = 0
             health = 0
+            ability = 0
             warmth = 0
             for abil in self.requirements[i]:
                 if abil == "EC":
@@ -184,6 +185,10 @@ class Connection:
                 elif abil == "HC":
                     health += 1
                     if self.sg.inventory["HC"] < health:
+                        score += self.sg.costs[abil.strip()]
+                elif abil == "AC":
+                    ability += 1
+                    if self.sg.inventory["AC"] < ability:
                         score += self.sg.costs[abil.strip()]
                 elif abil == "RB28":
                     warmth += 1
@@ -258,7 +263,7 @@ class SeedGenerator:
         """Part one of a reset. All initialization that doesn't
         require reading from params goes here."""
         self.costs = OrderedDict({
-            "Free": 0, "MS": 0, "KS": 2, "EC": 6, "HC": 12, "WallJump": 13,
+            "Free": 0, "MS": 0, "KS": 2, "AC": 12, "EC": 6, "HC": 12, "WallJump": 13,
             "ChargeFlame": 13, "DoubleJump": 13, "Bash": 41, "Stomp": 29,
             "Glide": 17, "Climb": 41, "ChargeJump": 59, "Dash": 13,
             "Grenade": 29, "GinsoKey": 12, "ForlornKey": 12, "HoruKey": 12,
@@ -495,11 +500,11 @@ class SeedGenerator:
                     cost = 0
                     cnts = defaultdict(lambda: 0)
                     for req in req_set:
-                        # for paired randomizer -- if the item isn't yours to assign, skip connection
-                        if self.itemPool[req] == 0:
-                            requirements = []
-                            break
                         if self.costs[req] > 0:
+                            # for paired randomizer -- if the item isn't yours to assign, skip connection
+                            if self.itemPool[req] == 0:
+                                requirements = []
+                                break
                             if req in ["HC", "EC", "WaterVeinShard", "GumonSealShard", "SunstoneShard", "RB28"]:
                                 cnts[req] += 1
                                 if cnts[req] > self.inventory[req]:
@@ -592,7 +597,7 @@ class SeedGenerator:
     def assign(self, item):
         self.itemPool[item] = max(
             self.itemPool[item] - 1, 0) if item in self.itemPool else 0
-        if item in ["EC", "KS", "HC", "WaterVeinShard", "GumonSealShard", "SunstoneShard"]:
+        if item in ["EC", "KS", "HC", "AC", "WaterVeinShard", "GumonSealShard", "SunstoneShard"]:
             if self.costs[item] > 0:
                 self.costs[item] -= 1
         elif item == "RB28":


### PR DESCRIPTION
Note: Variation.FREE_MAPSTONES will have to be added for this to work -- this variation should be enabled by default

Changes include:
-modified path difficulty determination to deal with difficult paths taken to 0-location areas
-increased cost for paths with 3 or more forced pickups involved (to avoid ability cell dumps for AC=12 paths)
-forced pickups are now factored, giving only a subset of what would be forced if that subset will unlock an area
-adds ability cells as a cost item (not included in spoilers, though)
-adds support for Variation.FREE_MAPSTONES
-cell frequency is now functional
-handling for open mode has been added (inventory item, ginso and horu teleporters)